### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/2014-03-03/aufgaben.slides.md
+++ b/2014-03-03/aufgaben.slides.md
@@ -85,7 +85,7 @@
 @. Welche deutschen Hochschulen betreiben seit wann und in welcher Form ein
    **Forschungsinformationssystem**? Erstellung eines übersichtlichen
    Vergleichs (Zusammenfassung des vorläufigen DINI-Berichts
-   "[**Forschungsinformationssysteme**](http://dx.doi.org/10.5281/zenodo.7697) 
+   "[**Forschungsinformationssysteme**](https://doi.org/10.5281/zenodo.7697) 
    in Hochschulen und Forschungseinrichtungen" (36 S.) vergleichbar mit 
    der vor fünf Jahren erstellten Übersicht von "Hochschulbibliografien an
    deutschen Hochschulen" (Voß & Scherer, 2009)

--- a/2014-04-14/identifier.slides.md
+++ b/2014-04-14/identifier.slides.md
@@ -174,7 +174,7 @@ $\Rightarrow$ `http://www.w3.org/2004/02/skos/core#prefLabel`
 * Struktur `10.` ORGANISATION `/` ID 
 * Einbindung in URI-System 
     * Präfix `doi:`
-    * URL-Präfix des IDF-Resolver `http://dx.doi.org/`
+    * URL-Präfix des IDF-Resolver `https://doi.org/`
 
 # Eigenschaften und Anforderungen and Identifikatoren
 

--- a/2014-05-26/forschungsdaten.slides.md
+++ b/2014-05-26/forschungsdaten.slides.md
@@ -28,7 +28,7 @@ Allianz der deutschen Wissenschaftsorganisationen^[<http://www.allianzinitiative
 
 # Beispiele
 
-<http://dx.doi.org/10.1594/PANGAEA.125848>
+<https://doi.org/10.1594/PANGAEA.125848>
 
 <https://www.youtube.com/watch?v=hrHM3bUym3g>
 


### PR DESCRIPTION
Hallo :-)

Die IDF hat seitdem [ihren resolver aktualisiert](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Ja, ein bisschen ironisch, dass sie auch die URL ändern, aber er kommuniziert jetzt [verschüsselt](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Da die alten, `dx`-Links umgeleitet werden, besteht keine Dringlichekeit für Änderungen, aber der Korrektheit halber möchte ich hiermit vorschlagen, alle DOI links zu aktualisieren.

Viele Grüße!